### PR TITLE
add pdflscape package

### DIFF
--- a/_extensions/hikmah-manuscript/include-in-header.tex
+++ b/_extensions/hikmah-manuscript/include-in-header.tex
@@ -116,6 +116,7 @@
 % 
 % BUT, from this http://stackoverflow.com/a/41945462/120898 we can get around
 % this by creating new commands for \begin and \end, like this:
+\usepackage{pdflscape}
 \newcommand{\blandscape}{\begin{landscape}}
 \newcommand{\elandscape}{\end{landscape}}
 

--- a/_extensions/hikmah/include-in-header.tex
+++ b/_extensions/hikmah/include-in-header.tex
@@ -148,6 +148,7 @@
 % 
 % BUT, from this http://stackoverflow.com/a/41945462/120898 we can get around
 % this by creating new commands for \begin and \end, like this:
+\usepackage{pdflscape}
 \newcommand{\blandscape}{\begin{landscape}}
 \newcommand{\elandscape}{\end{landscape}}
 


### PR DESCRIPTION
Hi,
The pdf templates are missing the pdflscape package to correctly use the \blandscape and \elandscape commands that you include in the template. This results in the following error when compiling the Latex document:
```
ERROR: 
compilation failed- no matching packages
LaTeX Error: Environment landscape undefined.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.468 \blandscape
```

This pull request just adds `\usepackage{pdflscape}` to the headers.